### PR TITLE
remove host, update flake, handle deprecations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758805352,
-        "narHash": "sha256-BHdc43Lkayd+72W/NXRKHzX5AZ+28F3xaUs3a88/Uew=",
+        "lastModified": 1771992996,
+        "narHash": "sha256-Y/ijH/unOPxzUicbla6yT/14RJgubUWnY2I2A6Ast2Q=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "c48e963a5558eb1c3827d59d21c5193622a1477c",
+        "rev": "3bfa436c1975674ca465ce34586467be301ff509",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759337100,
-        "narHash": "sha256-CcT3QvZ74NGfM+lSOILcCEeU+SnqXRvl1XCRHenZ0Us=",
+        "lastModified": 1772218752,
+        "narHash": "sha256-G8nArvOTZXU8DRvrzAdz3Elcj6kA/vMtvY9mrGLATtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "004753ae6b04c4b18aa07192c1106800aaacf6c3",
+        "rev": "f3a30376bb9eb2f6f61816be7d6ed954b6d2a3b9",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759133924,
-        "narHash": "sha256-eegjF6fo080481S/ZHyDENjeGG1ZgW2v86O9UZQxLJ8=",
+        "lastModified": 1772082373,
+        "narHash": "sha256-wySf8a6hvuqgFdwvvzPPTARBCMLDz7WFAufGkllD1M4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9547cfd27b5158eb612a6812dfc5c7b3d118b996",
+        "rev": "26eaeac4e409d7b5a6bf6f90a2a2dc223c78d915",
         "type": "github"
       },
       "original": {
@@ -94,25 +94,7 @@
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixpkgs-stable": "nixpkgs-stable",
-        "pkgs_kubectl_1_28_4": "pkgs_kubectl_1_28_4",
-        "thymesaver": "thymesaver"
-      }
-    },
-    "thymesaver": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1728512903,
-        "narHash": "sha256-Z8DwlOx2ioFbFF9bWciuLiI1ZFb9Mm8mt0fvFppvEvI=",
-        "ref": "main",
-        "rev": "09f17a92f27becc9be51080f080c9a9546be1e66",
-        "revCount": 621,
-        "type": "git",
-        "url": "ssh://git@github.com/thymecare/thymesaver"
-      },
-      "original": {
-        "ref": "main",
-        "type": "git",
-        "url": "ssh://git@github.com/thymecare/thymesaver"
+        "pkgs_kubectl_1_28_4": "pkgs_kubectl_1_28_4"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,13 +5,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-22.11";
 
-    # private repo - flake inputs are retrieved lazily so this won't
-    # error on machines that don't have access if unused
-    thymesaver = {
-      url = "git+ssh://git@github.com/thymecare/thymesaver?ref=main";
-      flake = false;
-    };
-
     # pinned package versions
     pkgs_kubectl_1_28_4.url = "github:nixos/nixpkgs?rev=ffb4d9542a9fab7cc5fe34fdaa5378d398ab3a99";
 
@@ -96,48 +89,6 @@
         username = "brian";
         hostname = "brian-air";
         system = "aarch64-darwin";
-      };
-
-      Thyme-M5772J33W1 = mkDarwinSystem rec {
-        username = "brianfogarty";
-        hostname = "Thyme-M5772J33W1";
-        system = "aarch64-darwin";
-        extraOverlays = [
-          # pin kubectl because max drift w/ server is +/-1 minor version
-          (self: super: { kubectl = (import inputs.pkgs_kubectl_1_28_4 { inherit system; }).pkgs.kubectl; })
-        ];
-
-        extraModules = [{
-          home-manager.users.${username} = {
-            programs.git.includes = [{
-              path = "${inputs.thymesaver}/dotfiles/.gitconfig";
-            }];
-
-            programs.fish.functions.thyme-dl = ''
-              git clone "git@github.com:thymecare/$argv[1].git" "$HOME/dev/$argv[1]"
-            '';
-
-            launchd.agents.thymeauth = {
-              enable = true;
-              config = {
-                ProgramArguments = [
-                  "${inputs.thymesaver}/bin/thyme_packages_auth"
-                ];
-                EnvironmentVariables = {
-                  PATH = let
-                    dependencies = [ "awscli2" "poetry" "coreutils" ];
-                  in
-                    builtins.concatStringsSep
-                      ":"
-                      (map (x: "${nixpkgs.legacyPackages.${system}.${x}}/bin") dependencies);
-                  AWS_PROFILE = "thyme-prod-engineering";
-                };
-                # every 6 hours (twice as often as required)
-                StartInterval = 7200;
-              };
-            };
-          };
-        }];
       };
     };
   };

--- a/home/default.nix
+++ b/home/default.nix
@@ -42,11 +42,11 @@ in {
     obsidian
     pgcli
     postgresql_16 # for psql
-    python311
-    python311Packages.grip
-    python311Packages.ipython
-    (poetry.override { python3 = python311; })
     rectangle
+    python313
+    python313Packages.grip
+    python313Packages.ipython
+    (poetry.override { python3 = python313; })
     ripgrep
     sentry-cli
     session-manager-plugin

--- a/home/default.nix
+++ b/home/default.nix
@@ -9,6 +9,7 @@ let
 
 in {
   imports = [
+    ./difftastic
     ./direnv
     ./eza
     ./fish

--- a/home/difftastic/default.nix
+++ b/home/difftastic/default.nix
@@ -1,0 +1,6 @@
+{
+  programs.difftastic = {
+    enable = true;
+    git.enable = true;
+  };
+}

--- a/home/git/default.nix
+++ b/home/git/default.nix
@@ -4,31 +4,29 @@
   programs.git = {
     enable = true;
 
-    userEmail = "brian@fogarty.email";
-    userName = "Brian Fogarty";
-
     signing = {
       key = "2742DCAE6B6532EB0B3085291BF984D7BCEC49A5";
       signByDefault = true;
     };
 
-    difftastic = {
-      enable = true;
-    };
+    settings = {
+      user = {
+        name = "Brian Fogarty";
+        email = "brian@fogarty.email";
+      };
 
-    extraConfig = {
+      aliases = {
+        s = "status -s";
+        l = "log --graph --oneline";
+        amend = "commit --amend";
+        last = "diff HEAD~ HEAD";
+        staged = "diff --staged";
+      };
+
       pull.rebase = true;
       diff.colorMoved = "zebra";
       init.defaultBranch = "main";
       push.autoSetupRemote = true;
-    };
-
-    aliases = {
-      s = "status -s";
-      l = "log --graph --oneline";
-      amend = "commit --amend";
-      last = "diff HEAD~ HEAD";
-      staged = "diff --staged";
     };
 
     ignores = [

--- a/home/git/default.nix
+++ b/home/git/default.nix
@@ -15,7 +15,7 @@
         email = "brian@fogarty.email";
       };
 
-      aliases = {
+      alias = {
         s = "status -s";
         l = "log --graph --oneline";
         amend = "commit --amend";

--- a/home/vim/default.nix
+++ b/home/vim/default.nix
@@ -16,11 +16,11 @@ in {
       dracula-vim
       nord-vim
       lightline-vim
-      vinegar
+      vim-vinegar
 
       # Code
       copilot-vim
-      fugitive
+      vim-fugitive
       vim-rhubarb
       vim-surround
       vim-commentary


### PR DESCRIPTION
Two flake changes:
- removes host `Thyme-M5772J33W1`
- updates system (`flake update`)

As a consequence of the system update:
- handles deprecations in `programs.git`
- handles renames for packages `vim-vinegar` and `vim-fugitive`

Finally, works around a broken `python311` build by upgrading the system python to `python313`.